### PR TITLE
AttributeError: module 'spikeextractors' has no attribute 'sorting_exporter_dict'

### DIFF
--- a/spikely/elements/exporterlist.py
+++ b/spikely/elements/exporterlist.py
@@ -5,7 +5,7 @@ exporters_list = []
 exporters_list.extend(se.extractorlist.writable_sorting_extractor_list)
 exporters_list.append(PhyExporter)
 
-se.sorting_exporter_dict
+se.sorting_extractor_dict
 
-sorting_exporter_dict = se.sorting_exporter_dict
+sorting_exporter_dict = se.sorting_extractor_dict
 sorting_exporter_dict[PhyExporter.exporter_name] = PhyExporter


### PR DESCRIPTION
'sorting_exporter_dict' should be changed to 'sorting_extractor_dict'